### PR TITLE
vnc-proxy: Bugfix restart procedure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 MAINTAINER Urs Roesch <github@bun.ch>
 
-#VERSION 1.2.0
+#VERSION 1.2.1
 ENV container docker
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/vnc-proxy.sh
+++ b/vnc-proxy.sh
@@ -12,18 +12,74 @@ trap restart EXIT
 # -----------------------------------------------------------------------------
 # Globals
 # -----------------------------------------------------------------------------
+declare -r SCRIPT_PATH=$(cd $(dirname ${BASH_ARGV0}); pwd)
+declare -r SCRIPT=${BASH_ARGV0##*/}
+declare -r VERSION=0.5.0
+declare -r AUTHOR="Urs Roesch"
+declare -r LICENSE=MIT
 declare -r SHORTNAME=$(hostname -s)
-declare -r NOVNC_PORT=${NOVNC_PORT:-6080}
+declare -i NOVNC_PORT=${NOVNC_PORT:-6080}
+declare -g NOVNC_DEBUG=${NOVNC_DEBUG:-false}
+declare -g NOVNC_LOOP=true
+declare -r NOVNC_TIMEOUT=10
 declare -r PACKER_VNC_START=5900
 declare -r PACKER_VNC_END=6000
 
 # -----------------------------------------------------------------------------
 # Functions
 # -----------------------------------------------------------------------------
+function usage() {
+  local exit_code=${1:-1}
+  cat <<USAGE
+
+  Usage:
+    ${SCRIPT} [options]
+
+  Options:
+    -h | --help         This message
+    -d | --debug        Run in debug mode e.g. shell tracing.
+    -p | --port <port>  Specify the port to listen on
+                        Default: ${NOVNC_PORT}
+    -V | --version      Display version and exit
+
+  Descriptions:
+    A small script searching for the packer VNC port and establishing
+    a novnc proxy to it. This allows monitoring and debuging the
+    progress of a packer build when running from within a container.
+
+USAGE
+  NOVNC_LOOP=false
+  exit ${exit_code}
+}
+
+function parse_options() {
+  while (( ${#} > 0 )); do
+    case "${1}" in
+    -d|--debug)   NOVNC_DEBUG=true;;
+    -p|--port)    shift; NOVNC_PORT=${1};;
+    -V|--version) version;;
+    -h|--help)    usage 0;;
+    esac
+    shift
+  done
+}
+
+function validate_options() {
+  [[ ${NOVNC_DEBUG} == true ]] && set -o xtrace || :
+}
+
+function version() {
+  printf "%s v%s\nCopyright (c) %s\nLicense - %s\n" \
+    "${SCRIPT}" "${VERSION}" "${AUTHOR}" "${LICENSE}"
+  NOVNC_LOOP=false
+  exit 0
+}
+
 function find_vnc_port() {
-  ss -Hntl src 127.0.0.1  and \
-   \( sport \>= ${PACKER_VNC_START} and sport \<= ${PACKER_VNC_END} \) | \
-   awk '{ print $4 }'
+  ss -Hntl \
+   "( src 127.0.0.1 or src [::1] )" and \
+   "( sport >= ${PACKER_VNC_START} and sport <= ${PACKER_VNC_END} )" | \
+   awk '{ print $4; exit }'
 }
 
 function wait_for_vnc() {
@@ -35,23 +91,44 @@ function wait_for_vnc() {
   echo ${vnc_address}
 }
 
+function stop_proxy() {
+  local pid=$(ps -ef | awk '/[n]ovnc_proxy/ { print $2 }')
+  kill -INT ${pid} || :
+}
+
+function check_status() {
+  local current_address=${1}; shift;
+  while [[ ${current_address} == "$(find_vnc_port)" ]]; do
+    sleep ${NOVNC_TIMEOUT};
+  done
+}
+
+function start_proxy() {
+  novnc_proxy \
+    --listen ${NOVNC_PORT} \
+    --vnc ${vnc_address} | \
+    sed -n -e "/${SHORTNAME}/ { s/${SHORTNAME}/localhost/g; p }"
+}
+
 function run_proxy() {
   local vnc_address=$(wait_for_vnc)
   local pid=''
-  ( novnc_proxy --listen ${NOVNC_PORT} --vnc ${vnc_address} | \
-    sed -n -e "/${SHORTNAME}/ { s/${SHORTNAME}/localhost/g; p }"
-  ) &
-  pid=$!
-  while [[ -n $(find_vnc_port) ]]; do sleep 10; done
-  [[ -n ${pid} ]] && kill ${pid}
+  start_proxy &
+  check_status ${vnc_address}
+  stop_proxy
 }
 
 function restart() {
-  sleep 10
-  run_proxy
+  local exit_code=$?
+  [[ ${NOVNC_LOOP} == false ]] && exit ${exit_code}
+  sleep ${NOVNC_TIMEOUT}
+  export NOVNC_PORT NOVNC_DEBUG
+  exec ${SCRIPT_PATH}/${SCRIPT}
 }
 
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
+parse_options "${@}"
+validate_options
 run_proxy


### PR DESCRIPTION
The proxy did not restart properly after the packer finished
and a new port was presented the old one was still active.
This change fixes the port detection and shutdown.

Basically instead of rerunning the loop start a new instance
of the script with exec. which solved the problem.

Also add help and debug options and a short description in
the usage output.